### PR TITLE
add: export getLoggerOrNoop function, remove markTimeline

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@
 const PROPS = 'memory'.split(',');
 
 const METHODS = ('assert,clear,count,debug,dir,dirxml,error,group,' +
-    'groupCollapsed,groupEnd,info,log,markTimeline,profile,profileEnd,' +
+    'groupCollapsed,groupEnd,info,log,profile,profileEnd,' +
     'table,time,timeEnd,timeStamp,trace,warn').split(',');
 
 let _stderr = console._stderr;
@@ -68,21 +68,22 @@ const noopConsole = function(con = {}) {
 
 const logger = function(con = {}, strict = false) {
     if (console._is_wrapped) return;
-    
+
     let methods = METHODS.concat(),
         method;
 
     while (method = methods.pop()) {
         if (console[method]) {
             con[method] = (function(m) {
+                const f = console[m];
                 return function() {
-                    console[m].apply(null, arguments);
+                    f.apply(null, arguments);
                 };
             })(method);
         } else {
             //e.g. node v6 does not have a debug method but v10 does.
             if (strict) throw new Error('Console does not have method' + method);
-            else console.error('Console does not have metohd ' + method);
+            else console.error('Console does not have method ' + method);
         }
     }
 
@@ -100,3 +101,15 @@ module.exports = noopConsole;
  * Exports empty logger;
  */
 module.exports.logger = logger;
+
+/**
+ * Get either a logger or a noop console.
+ *
+ * @param {String} env Current environment name
+ * @param {String} prod Environment name to mute console
+ * @returns {console}
+ */
+module.exports.getLoggerOrNoop = function $getLoggerOrNoop(env, prod = 'production') {
+    if (!env) env = process.env.NODE_ENV;
+    return env === prod ? noopConsole() : logger();
+};


### PR DESCRIPTION
This closes #2, #3, removes warnings caused by `markTimeline` and adds a new function `getLoggerOrNoop`.